### PR TITLE
fix s or q is empty can be parsed without defaults

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -191,7 +191,7 @@ func (p *Parser) Parse(query url.Values) *ParseResult {
 
 	// Apply force orderby
 	orderby = append(orderby, p.Metadata.ForceOrderBy...)
-	if paramOrderby, ok := query["s"]; ok && len(paramOrderby) >= 1 {
+	if paramOrderby, ok := query["s"]; ok && len(paramOrderby) >= 1 && len(paramOrderby[0]) > 0 {
 		// s query param is provided
 		orderbyVal := paramOrderby[0]
 		orderby = p.buildOrderby(orderbyVal, orderby)

--- a/parser.go
+++ b/parser.go
@@ -164,7 +164,7 @@ func (p *Parser) Parse(query url.Values) *ParseResult {
 	}
 
 	// Query
-	if paramQ, ok := query["q"]; ok && len(paramQ) >= 1 {
+	if paramQ, ok := query["q"]; ok && len(paramQ) >= 1 && len(paramQ[0]) > 0 {
 		qVal := paramQ[0]
 		for _, field := range strings.Split(qVal, "|") {
 			col, wh, arg, ok := p.buildWhereClause(field, p.Metadata.QueryMapping)

--- a/parser_test.go
+++ b/parser_test.go
@@ -783,3 +783,15 @@ func TestParseHavingWithNonExistField(t *testing.T) {
 		t.Fatalf("exp: %v, got: %v", expMap, res.HavingClause.ArgumentMap)
 	}
 }
+
+func TestParseQueryDefaultOrderByEmpty(t *testing.T) {
+	p := NewParser()
+	p.Metadata.DefaultOrderBy = []string{
+		"id DESC",
+		"created_at ASC",
+	}
+	res, _ := p.ParseQuery("s=")
+	if res.OrderByClause != "id DESC,created_at ASC" {
+		t.Fatalf("exp: %v, got: %v(length: %d)", "id DESC,created_at ASC", res.OrderByClause, len(res.OrderByClause))
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -795,3 +795,14 @@ func TestParseQueryDefaultOrderByEmpty(t *testing.T) {
 		t.Fatalf("exp: %v, got: %v(length: %d)", "id DESC,created_at ASC", res.OrderByClause, len(res.OrderByClause))
 	}
 }
+
+func TestParseQueryDefaultSearchEmpty(t *testing.T) {
+	p := NewParser()
+	p.Metadata.DefaultSearch = map[string]interface{}{
+		"id = ?": 1,
+	}
+	res, _ := p.ParseQuery("q=")
+	if res.WhereClause.Where != "id = ?" {
+		t.Fatalf("exp: %v, got: %v(length: %d)", "id = ?", res.WhereClause.Where, len(res.WhereClause.Where))
+	}
+}


### PR DESCRIPTION
fix s=<Empty> and q=<Empty> can skip DefaultSearch and DefaultOrderBy